### PR TITLE
更新 pubspec.lock 和 .gitignore 以进行构建输出和插件更改

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,19 @@ migrate_working_dir/
 # is commented out by default.
 #.vscode/
 
+# Build output directories
+windows/runner/Debug/
+linux/runner/Debug/
+macos/Runner/Debug/
+
+# Plugin build output directories
+plugins_dev/*/Debug/
+
+# Release build output
+build/windows/x64/runner/Release/
+build/linux/x64/runner/Release/
+build/macos/Runner/Release/
+
 # Flutter/Dart/Pub related
 **/doc/api/
 **/ios/Flutter/.last_build_id


### PR DESCRIPTION
- 更新 .gitignore 以排除 Windows、Linux 和 macOS 的调试和发布构建输出目录
- 更新 pubspec.lock 以使用 pub.flutter-io.cn 作为包源代码，并升级多个依赖版本，包括 async、fake_async 和 leak_tracker
- 重新生成适用于 Linux、macOS 和 Windows 平台的插件注册文件