### PR TITLE
为 AppSearch 插件结果添加 UTF-8 编码支持

### DIFF
--- a/lib/service.dart
+++ b/lib/service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -85,8 +86,16 @@ Future<List<ResultItemCard>> getResultItems(
         print('实时结果: $data');
       });*/
         //获取全部结果
+        // 对于AppSearch插件，使用UTF-8编码解码；对于其他插件，使用系统默认编码
+        StreamTransformer<List<int>, String> decoder;
+        if (item.name == "AppSearch") {
+          decoder = utf8.decoder;
+        } else {
+          decoder = systemEncoding.decoder;
+        }
+
         results = AddResultItemCardFromJson(
-          await process.stdout.transform(systemEncoding.decoder).join(),
+          await process.stdout.transform(decoder).join(),
           item.icon_path,
         );
         // 等待进程结束并获取退出码


### PR DESCRIPTION
支持对 AppSearch 插件输出进行 UTF-8 解码，同时对其他插件保持系统编码，以确保跨不同搜索源的正确文本处理。